### PR TITLE
Add projection views

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The module currently includes:
 * `account.projection` to record projected amounts and track their
   realization. Each projection must be linked to an account for
   traceability in reports and when matching real documents.
+* Tree and form views to create and manage projections from the
+  Accounting app.
 * `account.projection.realization` to link projections with
   `account.move` records for partial or full realization.
 * Categorization via `account.projection.category`.

--- a/account_projection/__manifest__.py
+++ b/account_projection/__manifest__.py
@@ -6,6 +6,7 @@
     'data': [
         'security/ir.model.access.csv',
         'views/account_move_views.xml',
+        'views/projection_views.xml',
         'views/projection_link_wizard_views.xml',
         'views/projection_report_views.xml',
         'report/projection_report.xml',

--- a/account_projection/views/projection_views.xml
+++ b/account_projection/views/projection_views.xml
@@ -1,0 +1,63 @@
+<odoo>
+    <record id="view_account_projection_tree" model="ir.ui.view">
+        <field name="name">account.projection.tree</field>
+        <field name="model">account.projection</field>
+        <field name="arch" type="xml">
+            <tree string="Projections">
+                <field name="name"/>
+                <field name="date_expected"/>
+                <field name="partner_id"/>
+                <field name="account_id"/>
+                <field name="amount"/>
+                <field name="amount_realized"/>
+                <field name="amount_remaining"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_account_projection_form" model="ir.ui.view">
+        <field name="name">account.projection.form</field>
+        <field name="model">account.projection</field>
+        <field name="arch" type="xml">
+            <form string="Projection">
+                <header>
+                    <button name="action_mark_draft" type="object" string="Set to Draft" states="cancelled,dropped,projected,partial,realized"/>
+                    <button name="action_mark_cancelled" type="object" string="Cancel" states="draft,projected,partial"/>
+                    <button name="action_mark_dropped" type="object" string="Drop" states="draft,projected,partial"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="partner_id"/>
+                        <field name="account_id"/>
+                        <field name="category_id"/>
+                        <field name="date_expected"/>
+                        <field name="amount"/>
+                        <field name="amount_realized" readonly="1"/>
+                        <field name="amount_remaining" readonly="1"/>
+                        <field name="state" readonly="1"/>
+                    </group>
+                    <notebook>
+                        <page string="Realizations">
+                            <field name="realization_ids">
+                                <tree editable="bottom">
+                                    <field name="move_id"/>
+                                    <field name="amount"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_account_projection" model="ir.actions.act_window">
+        <field name="name">Projections</field>
+        <field name="res_model">account.projection</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_account_projection" name="Projections" parent="account.menu_finance" action="action_account_projection"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add tree and form views for financial projections
- expose projections under Accounting menu
- document UI availability in README

## Testing
- `python -m pycodestyle account_projection` *(fails: No module named pycodestyle)*
- `pip install pycodestyle` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m compileall -q account_projection`

------
https://chatgpt.com/codex/tasks/task_e_68ae780eb9a0832c9686951adbf46861